### PR TITLE
Limit UserAgentFilter to 0.15.0 nodes

### DIFF
--- a/configs/mainnet-node-cf.json
+++ b/configs/mainnet-node-cf.json
@@ -14,11 +14,6 @@
     "NodeCF"
   ],
   "UserAgentFilter": [
-    "bchd:0.14.2",
-    "bchd:0.14.3",
-    "bchd:0.14.4",
-    "bchd:0.14.5",
-    "bchd:0.14.6",
-    "bchd:0.14.7"
+    "bchd:0.15.0"
   ]
 }


### PR DESCRIPTION
Updates `mainnet-node-cf.json` to only include 0.15.0 nodes since the cf filter format has changed.

This should be merged when the new version of Neutrino wallet is ready so we don't break wallet users.
