### PR TITLE
[Bug] Fix leak of BchDecoded objects

### DIFF
--- a/seeder.go
+++ b/seeder.go
@@ -394,8 +394,10 @@ func (s *dnsseeder) addNa(nNa *wire.NetAddress) bool {
 		return false
 	}
 
+	na := *nNa
+
 	nt := node{
-		NA:          nNa,
+		NA:          &na,
 		LastConnect: time.Now(),
 		Version:     0,
 		Status:      statusRG,
@@ -553,10 +555,8 @@ func (s *dnsseeder) auditNodes() {
 			}
 		}
 	}
-	if config.verbose {
-		log.Printf("%s: Audit complete. %v nodes purged\n", s.name, c)
-	}
 
+	log.Printf("%s: Audit complete. %v nodes purged. %v total nodes\n", s.name, c, len(s.theList))
 }
 
 // loadDNS loads the dns records with time based test data


### PR DESCRIPTION
This was a bit tricky, using pprof I noticed that BchDecode'd messages were not being released properly. This was because `nNa` was a pointer to an address that was inside of a slice in the node reply. By using this directly it was impossible to GC the original message.

With this fix pprof shows no memory being held by BchDecode'd objects anymore and I don't see it leaking. =)