### PR TITLE
[Chore] Make sure Node CF only uses BCHD 0.16.1

### DIFF
--- a/configs/mainnet-node-cf.json
+++ b/configs/mainnet-node-cf.json
@@ -14,9 +14,6 @@
     "NodeCF"
   ],
   "UserAgentFilter": [
-    "bchd:0.15.0",
-    "bchd:0.15.1",
-    "bchd:0.15.2",
-    "bchd:0.16.0"
+    "bchd:0.16.1"
   ]
 }

--- a/configs/testnet-node-cf.json
+++ b/configs/testnet-node-cf.json
@@ -13,9 +13,6 @@
     "NodeCF"
   ],
   "UserAgentFilter": [
-    "bchd:0.15.0",
-    "bchd:0.15.1",
-    "bchd:0.15.2",
-    "bchd:0.16.0"
+    "bchd:0.16.1"
   ]
 }


### PR DESCRIPTION
Upgrade has passed, old versions of BCHD are now useless.